### PR TITLE
Allow access to process

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,9 @@ let loadConfig = skipEvent => {
                         __filename: filePath,
                         module: {
                             exports: {}
+                        },
+                        process: {
+                          env: process.env
                         }
                     };
                     script.runInNewContext(sandbox);

--- a/index.js
+++ b/index.js
@@ -83,6 +83,7 @@ let loadConfig = skipEvent => {
                             exports: {}
                         },
                         process: {
+                          cwd: process.cwd,
                           env: process.env
                         }
                     };

--- a/index.js
+++ b/index.js
@@ -82,10 +82,7 @@ let loadConfig = skipEvent => {
                         module: {
                             exports: {}
                         },
-                        process: {
-                          cwd: process.cwd,
-                          env: process.env
-                        }
+                        process
                     };
                     script.runInNewContext(sandbox);
                     parsed = sandbox.module.exports;


### PR DESCRIPTION
PS: i'm not sure of the most usecase here OR if this would be useful to anyone.

tbh, I'm not totally sure of the rationale behind sandboxing the configurations, but while working with the tool, I've found it a bit difficult to do a few things, e.g dynamically configure my database.
One of the [12factor best practices](https://www.12factor.net) is to store configurations in the environment, but when the context of the environment is missing, it becomes a bit difficult to migrate things, especially when you want to keep things clean and don't want to ship any of dev config to prod, i.e. with `config/production.js` and `config/development.js`.
I'm not too sure of the most use case here, but I've found it easier to just allow access to the process(env, cwd etc) from the config. Although in the long run, i'd prefer the js config files not being placed within a sandboxed environment though.
As for security, like I've said I'm not totally sure of the most use case here, however if the purpose of the sandbox is to prevent a malicious attacker from gaining access, I think the purpose is probably already defeated if plugins are not loaded within the sandbox, because I'd assume any attacker that can launch within the context of the config, would probably already be able to launch anywhere else.