### PR TITLE
Fix env and argv parsing

### DIFF
--- a/example/config/default.toml
+++ b/example/config/default.toml
@@ -3,6 +3,7 @@ value=2
 
 [test]
 value=1
+bvalue=true
 # @include "../extra/includes.toml"
 
 [arr]

--- a/index.js
+++ b/index.js
@@ -228,15 +228,11 @@ let loadConfig = skipEvent => {
                         // null
                         return;
                     }
-                    if (Array.isArray(cParent[key])) {
-                        if (Array.isArray(eParent[key])) {
-                            return;
-                        }
-                        // convert to array
-                        eParent[key] = eParent[key].trim().split(/\s*,\s*/);
-                        return;
-                    }
                     return walkConfig(cParent[key], eParent[key]);
+                }
+                if (typeof eParent[key] === 'string' && Array.isArray(cParent[key])) {
+                    eParent[key] = eParent[key].trim().split(/\s*,\s*/);
+                    return;
                 }
             }
 

--- a/index.js
+++ b/index.js
@@ -223,7 +223,7 @@ let loadConfig = skipEvent => {
                     // null
                     return;
                 }
-                if (eParent[key] === 'object') {
+                if (typeof eParent[key] === 'object') {
                     if (!eParent[key]) {
                         // null
                         return;


### PR DESCRIPTION
Boolean (and probably numbers?) from arguments and environment variables wouldn't respect the type if they in subtrees. When fixing, also noticed arrays didn't look right, seems better now.

Two testing commands (with the modified config example):

    APPCONF_test_sub_arr="one,two" node index.js
    APPCONF_test_bvalue="false" node index.js